### PR TITLE
fix return example requirement 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Imagine que existem dois gatos, os quais chamaremos de `cat1` e `cat2`, e que am
 
 Sabendo disso, crie uma função chamada `catAndMouse` que, ao receber a posição de `mouse`, `cat1` e `cat2`, **nessa ordem**, calcule as distâncias entre o rato e os gatos e retorne qual dos felinos irá alcançar o rato primeiro (sendo aquele que estará mais perto).
 
-Exemplo: caso o gato `cat2` esteja a 2 unidades de distância do rato, e `cat1` esteja a 3 unidades, sua função deverá retornar `cat2`.
+Exemplo: caso o gato `cat2` esteja a 2 unidades de distância do rato, e `cat1` esteja a 3 unidades, sua função deverá retornar `"cat2"`.
 
 Caso os gatos estejam na mesma distância do rato, a função deverá retornar a string `"os gatos trombam e o rato foge"`.
 


### PR DESCRIPTION
Pessoas estudantes se confundiram ao ver o retorno com aspas em `"os gatos trombam e o rato foge"` e sem aspas em `cat2`